### PR TITLE
Align frontend/backend APIs, add user avatar/notifications, and expand dispute/notification endpoints

### DIFF
--- a/kahade-backend/prisma/schema/10_user_auth.prisma
+++ b/kahade-backend/prisma/schema/10_user_auth.prisma
@@ -35,6 +35,8 @@ model User {
   reputationScore   Decimal   @default(0) @db.Decimal(5, 2)
   totalTransactions Int       @default(0) @map("total_transactions")
   isAdmin           Boolean   @default(false) @map("is_admin")
+  avatarUrl         String?   @map("avatar_url")
+  notificationSettings Json?  @map("notification_settings")
 
   // Soft delete with FK to admin user
   deletedAt         DateTime? @map("deleted_at") @db.Timestamptz

--- a/kahade-backend/src/common/interfaces/user.interface.ts
+++ b/kahade-backend/src/common/interfaces/user.interface.ts
@@ -34,6 +34,8 @@ export interface IUser {
   reputationScore: number;
   totalTransactions: number;
   isAdmin: boolean;
+  avatarUrl?: string | null;
+  notificationSettings?: Record<string, boolean> | null;
   deletedAt?: Date;
   deletedByUserId?: string;
   createdAt: Date;
@@ -49,6 +51,8 @@ export interface IUserResponse {
   reputationScore: number;
   totalTransactions: number;
   isAdmin: boolean;
+  avatarUrl?: string | null;
+  notificationSettings?: Record<string, boolean> | null;
   createdAt: Date;
   updatedAt: Date;
 }

--- a/kahade-backend/src/core/admin/admin.controller.ts
+++ b/kahade-backend/src/core/admin/admin.controller.ts
@@ -18,6 +18,8 @@ import { Roles } from '@common/decorators/roles.decorator';
 import { CurrentUser } from '@common/decorators/current-user.decorator';
 import { PrismaService } from '@infrastructure/database/prisma.service';
 import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse, ApiQuery } from '@nestjs/swagger';
+import { DisputeService } from '../dispute/dispute.service';
+import { DisputeDecision } from '@common/shims/prisma-types.shim';
 
 // ============================================================================
 // ADMIN CONTROLLER - Production Ready
@@ -30,7 +32,10 @@ import { ApiTags, ApiBearerAuth, ApiOperation, ApiResponse, ApiQuery } from '@ne
 export class AdminController {
   private readonly logger = new Logger(AdminController.name);
 
-  constructor(private readonly prisma: PrismaService) {}
+  constructor(
+    private readonly prisma: PrismaService,
+    private readonly disputeService: DisputeService,
+  ) {}
 
   // ============================================================================
   // DASHBOARD
@@ -614,55 +619,72 @@ export class AdminController {
   async resolveDispute(
     @Param('id') id: string,
     @CurrentUser('id') adminId: string,
-    @Body() dto: { winner: 'buyer' | 'seller' | 'split'; resolution: string },
+    @Body()
+    dto: {
+      winner?: 'buyer' | 'seller' | 'split';
+      resolution?: string;
+      decision?: DisputeDecision;
+      resolutionNotes?: string;
+      buyerRefundMinor?: string;
+      sellerAmountMinor?: string;
+    },
   ) {
-    if (!dto.resolution) {
+    const resolutionNotes = dto.resolutionNotes || dto.resolution;
+
+    if (!resolutionNotes) {
       throw new BadRequestException('Resolution details required');
     }
 
-    const dispute = await (this.prisma as any).dispute.findUnique({
-      where: { id },
-      include: { order: true },
-    });
+    let decision = dto.decision;
 
-    if (!dispute) {
-      throw new NotFoundException('Dispute not found');
+    if (!decision) {
+      if (dto.winner === 'buyer') {
+        decision = DisputeDecision.REFUND_ALL_TO_BUYER;
+      } else if (dto.winner === 'seller') {
+        decision = DisputeDecision.RELEASE_ALL_TO_SELLER;
+      } else {
+        decision = DisputeDecision.SPLIT_SETTLEMENT;
+      }
     }
 
-    let decision = 'SPLIT_SETTLEMENT';
-    if (dto.winner === 'buyer') {
-      decision = 'REFUND_ALL_TO_BUYER';
-    } else if (dto.winner === 'seller') {
-      decision = 'RELEASE_ALL_TO_SELLER';
-    }
-
-    await (this.prisma as any).dispute.update({
-      where: { id },
-      data: {
-        status: 'CLOSED',
-        decision,
-        resolution: dto.resolution,
-        resolvedAt: new Date(),
-        resolvedBy: adminId,
-      },
-    });
-
-    // Update order status
-    const orderStatus = dto.winner === 'buyer' ? 'REFUNDED' : 'COMPLETED';
-    await (this.prisma as any).order.update({
-      where: { id: dispute.orderId },
-      data: { status: orderStatus },
+    await this.disputeService.resolve(id, adminId, {
+      decision,
+      resolutionNotes,
+      buyerRefundMinor: dto.buyerRefundMinor,
+      sellerAmountMinor: dto.sellerAmountMinor,
     });
 
     await this.createAuditLog(adminId, 'UPDATE', 'Dispute', id, {
       action: 'RESOLVED',
-      winner: dto.winner,
-      resolution: dto.resolution,
+      decision,
+      resolutionNotes,
     });
 
     this.logger.log(`Dispute ${id} resolved by admin ${adminId}`);
 
     return { message: 'Dispute resolved successfully' };
+  }
+
+  @Post('disputes/:id/assign')
+  @Roles('ADMIN')
+  @ApiOperation({ summary: 'Assign arbitrator to dispute' })
+  async assignArbitrator(
+    @Param('id') id: string,
+    @CurrentUser('id') adminId: string,
+    @Body('arbitratorId') arbitratorId: string,
+  ) {
+    if (!arbitratorId) {
+      throw new BadRequestException('Arbitrator ID is required');
+    }
+
+    await this.disputeService.assignArbitrator(id, adminId, arbitratorId);
+
+    await this.createAuditLog(adminId, 'UPDATE', 'Dispute', id, {
+      action: 'ARBITRATOR_ASSIGNED',
+      arbitratorId,
+    });
+
+    return { message: 'Arbitrator assigned successfully' };
   }
 
   // ============================================================================

--- a/kahade-backend/src/core/admin/admin.module.ts
+++ b/kahade-backend/src/core/admin/admin.module.ts
@@ -1,9 +1,10 @@
 import { Module } from '@nestjs/common';
 import { AdminController } from './admin.controller';
 import { DatabaseModule } from '@infrastructure/database/database.module';
+import { DisputeModule } from '../dispute/dispute.module';
 
 @Module({
-  imports: [DatabaseModule],
+  imports: [DatabaseModule, DisputeModule],
   controllers: [AdminController],
   providers: [],
   exports: [],

--- a/kahade-backend/src/core/dispute/dispute.controller.ts
+++ b/kahade-backend/src/core/dispute/dispute.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Put, Body, Param, Query, UseGuards } from '@nestjs/common';
+import { Controller, Get, Post, Put, Body, Param, Query, UseGuards, BadRequestException } from '@nestjs/common';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiQuery } from '@nestjs/swagger';
 import { DisputeService, CreateDisputeDto as ServiceCreateDisputeDto, ResolveDisputeDto as ServiceResolveDisputeDto } from './dispute.service';
 import { CreateDisputeDto } from './dto/create-dispute.dto';
@@ -44,6 +44,67 @@ export class DisputeController {
   @ApiResponse({ status: 404, description: 'Dispute not found' })
   async findOne(@Param('id') id: string, @CurrentUser('id') userId: string) {
     return this.disputeService.findOne(id, userId);
+  }
+
+  @Post(':id/respond')
+  @ApiOperation({ summary: 'Respond to dispute (counterparty)' })
+  @ApiResponse({ status: 200, description: 'Dispute responded' })
+  async respond(
+    @Param('id') id: string,
+    @CurrentUser('id') userId: string,
+    @Body('response') response: string,
+  ) {
+    if (!response || response.trim().length < 5) {
+      throw new BadRequestException('Response must be at least 5 characters');
+    }
+    return this.disputeService.respond(id, userId, response.trim());
+  }
+
+  @Post(':id/evidence')
+  @ApiOperation({ summary: 'Submit dispute evidence' })
+  @ApiResponse({ status: 200, description: 'Evidence submitted' })
+  async submitEvidence(
+    @Param('id') id: string,
+    @CurrentUser('id') userId: string,
+    @Body()
+    body: {
+      fileUrls: string[];
+      description: string;
+    },
+  ) {
+    if (!body.fileUrls || body.fileUrls.length === 0) {
+      throw new BadRequestException('Evidence file URLs are required');
+    }
+    if (!body.description || body.description.trim().length < 10) {
+      throw new BadRequestException('Evidence description must be at least 10 characters');
+    }
+
+    await this.disputeService.submitEvidence(id, userId, body.fileUrls, body.description.trim());
+    return { message: 'Evidence submitted successfully' };
+  }
+
+  @Get(':id/messages')
+  @ApiOperation({ summary: 'Get dispute messages' })
+  @ApiResponse({ status: 200, description: 'Returns dispute messages' })
+  async getMessages(@Param('id') id: string, @CurrentUser('id') userId: string) {
+    return this.disputeService.getMessages(id, userId);
+  }
+
+  @Post(':id/messages')
+  @ApiOperation({ summary: 'Add dispute message' })
+  @ApiResponse({ status: 201, description: 'Message sent' })
+  async addMessage(
+    @Param('id') id: string,
+    @CurrentUser('id') userId: string,
+    @Body('message') message: string,
+  ) {
+    if (!message || message.trim().length === 0) {
+      throw new BadRequestException('Message cannot be empty');
+    }
+    if (message.length > 1000) {
+      throw new BadRequestException('Message must not exceed 1000 characters');
+    }
+    return this.disputeService.addMessage(id, userId, message.trim());
   }
 
   @Put(':id/resolve')

--- a/kahade-backend/src/core/dispute/dispute.service.ts
+++ b/kahade-backend/src/core/dispute/dispute.service.ts
@@ -439,4 +439,53 @@ export class DisputeService {
 
     this.logger.log(`Evidence submitted for dispute ${disputeId} by ${userId}`);
   }
+
+  async getMessages(disputeId: string, userId: string) {
+    const dispute = await this.findOne(disputeId, userId);
+
+    const messages = await this.prisma.disputeTimeline.findMany({
+      where: {
+        disputeId: dispute.id,
+        action: 'MESSAGE',
+      },
+      include: {
+        user: { select: { id: true, username: true } },
+      },
+      orderBy: { createdAt: 'asc' },
+    });
+
+    return messages.map((message: any) => ({
+      id: message.id,
+      message: message.details?.message,
+      createdAt: message.createdAt,
+      sender: message.user,
+    }));
+  }
+
+  async addMessage(disputeId: string, userId: string, message: string) {
+    const dispute = await this.findOne(disputeId, userId);
+
+    const order = await this.prisma.order.findUnique({
+      where: { id: dispute.orderId },
+    });
+
+    if (!order) {
+      throw new NotFoundException('Order not found');
+    }
+
+    if (order.initiatorId !== userId && order.counterpartyId !== userId) {
+      throw new ForbiddenException('Not authorized to message in this dispute');
+    }
+
+    await this.prisma.disputeTimeline.create({
+      data: {
+        disputeId,
+        action: 'MESSAGE',
+        performedBy: userId,
+        details: { message },
+      },
+    });
+
+    return { message: 'Message sent' };
+  }
 }

--- a/kahade-backend/src/core/notification/notification.controller.ts
+++ b/kahade-backend/src/core/notification/notification.controller.ts
@@ -34,6 +34,14 @@ export class NotificationController {
     return { count };
   }
 
+  @Get('unread-count')
+  @ApiOperation({ summary: 'Get unread notifications count (legacy route)' })
+  @ApiResponse({ status: 200, description: 'Returns count' })
+  async countUnreadLegacy(@CurrentUser('id') userId: string) {
+    const count = await this.notificationService.countUnread(userId);
+    return { count };
+  }
+
   @Patch(':id/read')
   @ApiOperation({ summary: 'Mark notification as read' })
   @ApiResponse({ status: 200, description: 'Notification marked as read' })
@@ -54,5 +62,13 @@ export class NotificationController {
   async delete(@Param('id') id: string, @CurrentUser('id') userId: string) {
     await this.notificationService.delete(id, userId);
     return { message: 'Notification deleted successfully' };
+  }
+
+  @Delete()
+  @ApiOperation({ summary: 'Delete all notifications' })
+  @ApiResponse({ status: 200, description: 'Notifications deleted' })
+  async deleteAll(@CurrentUser('id') userId: string) {
+    const result = await this.notificationService.deleteAll(userId);
+    return { message: 'Notifications deleted successfully', ...result };
   }
 }

--- a/kahade-backend/src/core/transaction/transaction.controller.ts
+++ b/kahade-backend/src/core/transaction/transaction.controller.ts
@@ -276,4 +276,36 @@ export class TransactionController {
     }
     return this.transactionService.sendMessage(id, userId, message.trim());
   }
+
+  // ============================================================================
+  // TRANSACTION RATING
+  // ============================================================================
+
+  @Post(':id/rating')
+  @Throttle({ default: { limit: 10, ttl: 3600000 } })
+  @ApiOperation({ summary: 'Rate completed transaction' })
+  @ApiParam({ name: 'id', description: 'Transaction ID' })
+  @ApiBody({
+    schema: {
+      properties: {
+        score: { type: 'number', minimum: 1, maximum: 5 },
+        comment: { type: 'string', maxLength: 1000 },
+      },
+      required: ['score'],
+    },
+  })
+  @ApiResponse({ status: 200, description: 'Rating submitted' })
+  async rateTransaction(
+    @Param('id') id: string,
+    @CurrentUser('id') userId: string,
+    @Body() data: { score: number; comment?: string },
+  ) {
+    if (!data.score || data.score < 1 || data.score > 5) {
+      throw new BadRequestException('Score must be between 1 and 5');
+    }
+    if (data.comment && data.comment.length > 1000) {
+      throw new BadRequestException('Comment must not exceed 1000 characters');
+    }
+    return this.transactionService.rate(id, userId, data);
+  }
 }

--- a/kahade-backend/src/core/user/user.controller.ts
+++ b/kahade-backend/src/core/user/user.controller.ts
@@ -1,4 +1,4 @@
-import { Controller, Get, Post, Patch, Body, Param, Query, UseGuards, UseInterceptors, UploadedFile } from '@nestjs/common';
+import { Controller, Get, Post, Patch, Body, Param, Query, UseGuards, UseInterceptors, UploadedFile, BadRequestException } from '@nestjs/common';
 import { FileInterceptor } from '@nestjs/platform-express';
 import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiQuery, ApiConsumes } from '@nestjs/swagger';
 import { UserService } from './user.service';
@@ -8,6 +8,7 @@ import { JwtAuthGuard } from '@common/guards/jwt-auth.guard';
 import { RolesGuard } from '@common/guards/roles.guard';
 import { CurrentUser } from '@common/decorators/current-user.decorator';
 import { Roles } from '@common/decorators/roles.decorator';
+import { Express } from 'express';
 
 @ApiTags('user')
 @Controller('user')
@@ -55,6 +56,56 @@ export class UserController {
     @Body() dto: UploadKycDto,
   ) {
     return this.userService.uploadKYCDocument(userId, file, dto);
+  }
+
+  @Post('avatar')
+  @ApiOperation({ summary: 'Upload user avatar' })
+  @ApiConsumes('multipart/form-data')
+  @ApiResponse({ status: 200, description: 'Avatar updated successfully' })
+  @UseInterceptors(FileInterceptor('avatar'))
+  async uploadAvatar(
+    @CurrentUser('id') userId: string,
+    @UploadedFile() file: Express.Multer.File,
+  ) {
+    if (!file) {
+      throw new BadRequestException('Avatar file is required');
+    }
+    if (!file.mimetype.startsWith('image/')) {
+      throw new BadRequestException('Avatar must be an image');
+    }
+    if (file.size > 5 * 1024 * 1024) {
+      throw new BadRequestException('Avatar file size must not exceed 5MB');
+    }
+
+    return this.userService.updateAvatar(userId, file);
+  }
+
+  @Get('stats')
+  @ApiOperation({ summary: 'Get user statistics' })
+  @ApiResponse({ status: 200, description: 'Returns user statistics' })
+  async getStats(@CurrentUser('id') userId: string) {
+    return this.userService.getStats(userId);
+  }
+
+  @Patch('notification-settings')
+  @ApiOperation({ summary: 'Update notification settings' })
+  @ApiResponse({ status: 200, description: 'Notification settings updated' })
+  async updateNotificationSettings(
+    @CurrentUser('id') userId: string,
+    @Body()
+    settings: {
+      email?: boolean;
+      push?: boolean;
+      transaction?: boolean;
+      marketing?: boolean;
+    },
+  ) {
+    return this.userService.updateNotificationSettings(userId, {
+      email: !!settings.email,
+      push: !!settings.push,
+      transaction: !!settings.transaction,
+      marketing: !!settings.marketing,
+    });
   }
 
   @Get(':id/ratings')

--- a/kahade-backend/src/core/user/user.repository.ts
+++ b/kahade-backend/src/core/user/user.repository.ts
@@ -21,6 +21,8 @@ export interface IUpdateUser {
   lastLoginAt?: Date;
   failedLoginCount?: number;
   lockedUntil?: Date;
+  avatarUrl?: string | null;
+  notificationSettings?: Record<string, boolean> | null;
   // Password management
   passwordHash?: string;
   passwordUpdatedAt?: Date;

--- a/kahade-backend/src/core/user/user.service.ts
+++ b/kahade-backend/src/core/user/user.service.ts
@@ -6,6 +6,8 @@ import { IUserResponse, KYCStatus } from '@common/interfaces/user.interface';
 import { User } from '@common/shims/prisma-types.shim';
 import { PrismaService } from '@infrastructure/database/prisma.service';
 import { UploadKycDto } from './dto/upload-kyc.dto';
+import * as fs from 'fs';
+import * as path from 'path';
 import * as bcrypt from 'bcrypt';
 import * as crypto from 'crypto';
 
@@ -16,6 +18,7 @@ import * as crypto from 'crypto';
 @Injectable()
 export class UserService {
   private readonly logger = new Logger(UserService.name);
+  private readonly AVATAR_UPLOAD_DIR = process.env.AVATAR_UPLOAD_DEST || './uploads/avatars';
 
   constructor(
     private readonly userRepository: UserRepository,
@@ -195,6 +198,75 @@ export class UserService {
     return {
       message: 'KYC document uploaded successfully',
       status: 'PENDING',
+    };
+  }
+
+  // ============================================================================
+  // PROFILE & SETTINGS
+  // ============================================================================
+
+  async updateNotificationSettings(
+    userId: string,
+    settings: Record<string, boolean>,
+  ): Promise<IUserResponse> {
+    const updated = await this.userRepository.update(userId, {
+      notificationSettings: settings,
+    });
+    return this.sanitizeUser(updated);
+  }
+
+  async updateAvatar(userId: string, file: Express.Multer.File): Promise<IUserResponse> {
+    if (!fs.existsSync(this.AVATAR_UPLOAD_DIR)) {
+      fs.mkdirSync(this.AVATAR_UPLOAD_DIR, { recursive: true });
+    }
+
+    const fileExt = file.originalname.split('.').pop()?.toLowerCase() || 'jpg';
+    const fileHash = crypto.createHash('sha256').update(file.buffer).digest('hex');
+    const fileName = `${Date.now()}_${fileHash.substring(0, 8)}.${fileExt}`;
+    const filePath = path.join(this.AVATAR_UPLOAD_DIR, fileName);
+    const relativePath = `/uploads/avatars/${fileName}`;
+
+    fs.writeFileSync(filePath, file.buffer);
+
+    const updated = await this.userRepository.update(userId, {
+      avatarUrl: relativePath,
+    });
+
+    this.logger.log(`Avatar updated for user ${userId}`);
+
+    return this.sanitizeUser(updated);
+  }
+
+  async getStats(userId: string): Promise<{
+    totalTransactions: number;
+    completedTransactions: number;
+    disputeCount: number;
+  }> {
+    const where = {
+      deletedAt: null,
+      OR: [{ initiatorId: userId }, { counterpartyId: userId }],
+    };
+
+    const [totalTransactions, completedTransactions, disputeCount] = await Promise.all([
+      (this.prisma as any).order.count({ where }),
+      (this.prisma as any).order.count({
+        where: {
+          ...where,
+          status: 'COMPLETED',
+        },
+      }),
+      (this.prisma as any).order.count({
+        where: {
+          ...where,
+          status: 'DISPUTED',
+        },
+      }),
+    ]);
+
+    return {
+      totalTransactions,
+      completedTransactions,
+      disputeCount,
     };
   }
 

--- a/kahade-backend/src/main.ts
+++ b/kahade-backend/src/main.ts
@@ -118,8 +118,9 @@ async function bootstrap() {
       'X-Idempotency-Key',
       'X-MFA-Token',
       'X-Request-ID',
+      'X-XSRF-Token',
     ],
-    exposedHeaders: ['X-Request-ID', 'X-RateLimit-Remaining'],
+    exposedHeaders: ['X-Request-ID', 'X-RateLimit-Remaining', 'X-CSRF-Token'],
     maxAge: 86400, // 24 hours
   });
 

--- a/kahade-frontend/client/src/contexts/AuthContext.tsx
+++ b/kahade-frontend/client/src/contexts/AuthContext.tsx
@@ -71,6 +71,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     } catch (error) {
       localStorage.removeItem('kahade_token');
       localStorage.removeItem('kahade_user');
+      localStorage.removeItem('kahade_refresh_token');
       setUser(null);
       throw error;
     }
@@ -107,10 +108,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     setIsLoading(true);
     try {
       const response = await authApi.login({ email, password });
-      const { accessToken, token, user: userData } = response.data;
+      const { accessToken, token, refreshToken, user: userData } = response.data;
       
       const authToken = accessToken || token;
       localStorage.setItem('kahade_token', authToken);
+      if (refreshToken) {
+        localStorage.setItem('kahade_refresh_token', refreshToken);
+      }
       
       let mappedUser: User;
       if (userData) {
@@ -137,6 +141,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     } catch (error: any) {
       localStorage.removeItem('kahade_token');
       localStorage.removeItem('kahade_user');
+      localStorage.removeItem('kahade_refresh_token');
       throw new Error(error.response?.data?.message || 'Login failed');
     } finally {
       setIsLoading(false);
@@ -152,10 +157,13 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         password: data.password,
       });
       
-      const { accessToken, token, user: userData } = response.data;
+      const { accessToken, token, refreshToken, user: userData } = response.data;
       
       if (accessToken || token) {
         localStorage.setItem('kahade_token', accessToken || token);
+        if (refreshToken) {
+          localStorage.setItem('kahade_refresh_token', refreshToken);
+        }
         
         if (userData) {
           const mappedUser = mapUserData(userData, data.username);
@@ -187,6 +195,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     } finally {
       localStorage.removeItem('kahade_token');
       localStorage.removeItem('kahade_user');
+      localStorage.removeItem('kahade_refresh_token');
       setUser(null);
       
       // Redirect to landing page after logout

--- a/kahade-frontend/client/src/lib/api.ts
+++ b/kahade-frontend/client/src/lib/api.ts
@@ -6,7 +6,8 @@
  */
 
 import axios, { AxiosError, AxiosRequestConfig, AxiosResponse } from 'axios';
-import { APP_URLS, COOKIE_CONFIG } from '@/config/app.config';
+import { APP_URLS } from '@/config/app.config';
+import { SecureStorage } from '@/lib/secure-storage';
 
 // Base API URL - from centralized config
 const API_BASE_URL = APP_URLS.api;
@@ -17,6 +18,7 @@ const REQUEST_TIMEOUT = 30000;
 // Token storage keys
 const TOKEN_KEY = 'kahade_token';
 const USER_KEY = 'kahade_user';
+const REFRESH_TOKEN_KEY = 'kahade_refresh_token';
 
 // Create axios instance with default config
 const api = axios.create({
@@ -42,6 +44,11 @@ api.interceptors.request.use(
       config.headers.Authorization = `Bearer ${token}`;
     }
 
+    const csrfToken = SecureStorage.getCsrfToken();
+    if (csrfToken) {
+      config.headers['x-xsrf-token'] = csrfToken;
+    }
+
     // Add request ID for tracing
     config.headers['X-Request-ID'] = generateRequestId();
 
@@ -65,7 +72,13 @@ api.interceptors.request.use(
 
 // Response interceptor for error handling
 api.interceptors.response.use(
-  (response: AxiosResponse) => response,
+  (response: AxiosResponse) => {
+    const csrfToken = response.headers['x-csrf-token'];
+    if (csrfToken) {
+      SecureStorage.setCsrfToken(csrfToken);
+    }
+    return response;
+  },
   async (error: AxiosError) => {
     const originalRequest = error.config as AxiosRequestConfig & { _retry?: boolean };
 
@@ -78,11 +91,15 @@ api.interceptors.response.use(
         try {
           const refreshResponse = await authApi.refreshToken();
           const newToken = refreshResponse.data.accessToken || refreshResponse.data.token;
+          const newRefreshToken = refreshResponse.data.refreshToken;
           
           if (newToken) {
             localStorage.setItem(TOKEN_KEY, newToken);
             if (originalRequest.headers) {
               originalRequest.headers.Authorization = `Bearer ${newToken}`;
+            }
+            if (newRefreshToken) {
+              localStorage.setItem(REFRESH_TOKEN_KEY, newRefreshToken);
             }
             return api(originalRequest);
           }
@@ -120,6 +137,7 @@ api.interceptors.response.use(
 function clearAuth(): void {
   localStorage.removeItem(TOKEN_KEY);
   localStorage.removeItem(USER_KEY);
+  localStorage.removeItem(REFRESH_TOKEN_KEY);
 }
 
 function redirectToLogin(): void {
@@ -155,11 +173,17 @@ export const authApi = {
   
   me: () => api.get('/auth/me'),
   
-  logout: () => api.post('/auth/logout'),
+  logout: () => {
+    const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY);
+    return api.post('/auth/logout', refreshToken ? { refreshToken } : {});
+  },
   
   logoutAll: () => api.post('/auth/logout-all'),
   
-  refreshToken: () => api.post('/auth/refresh'),
+  refreshToken: () => {
+    const refreshToken = localStorage.getItem(REFRESH_TOKEN_KEY);
+    return api.post('/auth/refresh', refreshToken ? { refreshToken } : {});
+  },
   
   // 2FA
   enable2FA: () => api.post('/auth/2fa/enable'),
@@ -180,16 +204,16 @@ export const authApi = {
 
 // User API
 export const userApi = {
-  getProfile: () => api.get('/users/me'),
+  getProfile: () => api.get('/user/profile'),
   
   updateProfile: (data: { username?: string; phone?: string }) =>
-    api.patch('/users/me', data),
+    api.patch('/user/profile', data),
   
   changePassword: (data: { currentPassword: string; newPassword: string }) =>
-    api.post('/users/me/change-password', data),
+    api.post('/user/change-password', data),
   
   uploadAvatar: (data: FormData) =>
-    api.post('/users/me/avatar', data, {
+    api.post('/user/avatar', data, {
       headers: { 'Content-Type': 'multipart/form-data' },
     }),
   
@@ -200,14 +224,14 @@ export const userApi = {
   
   getKYCStatus: () => api.get('/kyc/status'),
   
-  getStats: () => api.get('/users/me/stats'),
+  getStats: () => api.get('/user/stats'),
   
   updateNotificationSettings: (data: {
     email?: boolean;
     push?: boolean;
     transaction?: boolean;
     marketing?: boolean;
-  }) => api.patch('/users/me/notification-settings', data),
+  }) => api.patch('/user/notification-settings', data),
   
   getPublicProfile: (userId: string) => api.get(`/users/${userId}`),
   
@@ -288,7 +312,7 @@ export const notificationApi = {
   list: (params?: { read?: boolean; page?: number; limit?: number }) =>
     api.get('/notifications', { params }),
   
-  getUnreadCount: () => api.get('/notifications/unread-count'),
+  getUnreadCount: () => api.get('/notifications/unread/count'),
   
   markRead: (id: string) => api.patch(`/notifications/${id}/read`),
   
@@ -317,10 +341,8 @@ export const disputeApi = {
   respond: (id: string, response: string) =>
     api.post(`/disputes/${id}/respond`, { response }),
   
-  addEvidence: (id: string, data: FormData) =>
-    api.post(`/disputes/${id}/evidence`, data, {
-      headers: { 'Content-Type': 'multipart/form-data' },
-    }),
+  addEvidence: (id: string, data: { fileUrls: string[]; description: string }) =>
+    api.post(`/disputes/${id}/evidence`, data),
   
   addMessage: (id: string, message: string) =>
     api.post(`/disputes/${id}/messages`, { message }),


### PR DESCRIPTION
### Motivation
- Fix API mismatches between frontend and backend (routes, CSRF headers, refresh tokens) so clients and server talk the same protocol.
- Persist user avatar and per-user notification settings in the database and surface endpoints to manage them.
- Add richer dispute flows (messages, evidence submission validation) and admin helpers (resolve via service, assign arbitrator) to support production dispute workflows.

### Description
- Prisma schema: added `avatarUrl` and `notificationSettings` fields to `User` in `prisma/schema/10_user_auth.prisma`.
- Backend user changes: extended `IUpdateUser`, updated `IUser`/`IUserResponse` interfaces, implemented `updateAvatar`, `updateNotificationSettings`, and `getStats` in `UserService`, added `/user/avatar`, `/user/stats`, and `/user/notification-settings` endpoints in `user.controller.ts`, and persisted avatars to `./uploads/avatars` by default.
- Dispute and notification enhancements: added message and evidence endpoints/validation in `dispute.controller.ts` and `dispute.service.ts`, added delete-all and legacy unread-count routes in `notification.controller.ts`, and added transaction rating endpoint in `transaction.controller.ts`.
- Admin flow: delegated dispute resolution to `DisputeService`, added `assignArbitrator` endpoint, and wired `DisputeModule` into `AdminModule`.
- Frontend API and auth: aligned route paths, added CSRF token handling and secure storage integration in `client/src/lib/api.ts`, added refresh token storage and usage in `AuthContext.tsx`, and updated calls to use the new endpoints.
- CORS/headers: exposed CSRF header and allowed XSRF token header in `kahade-backend/src/main.ts` to support CSRF protection for the client.

### Testing
- No automated tests were executed for this changeset as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69775b77b6ec8324aca3186434d7e882)