### PR TITLE
Add MFA & session management, harden webhooks, and align backend/frontend config/flows

### DIFF
--- a/kahade-backend/src/api/webhooks/xendit.webhook.controller.ts
+++ b/kahade-backend/src/api/webhooks/xendit.webhook.controller.ts
@@ -321,10 +321,19 @@ export class XenditWebhookController {
 
     // Xendit uses a simple token comparison
     // For production, use timing-safe comparison to prevent timing attacks
-    return crypto.timingSafeEqual(
-      Buffer.from(callbackToken),
-      Buffer.from(this.webhookToken),
-    );
+    if (callbackToken.length !== this.webhookToken.length) {
+      return false;
+    }
+
+    try {
+      return crypto.timingSafeEqual(
+        Buffer.from(callbackToken),
+        Buffer.from(this.webhookToken),
+      );
+    } catch (error) {
+      this.logger.error(`Callback token comparison error: ${error.message}`);
+      return false;
+    }
   }
 
   /**
@@ -340,10 +349,19 @@ export class XenditWebhookController {
       .update(payload)
       .digest('hex');
 
-    return crypto.timingSafeEqual(
-      Buffer.from(signature),
-      Buffer.from(expectedSignature),
-    );
+    if (signature.length !== expectedSignature.length) {
+      return false;
+    }
+
+    try {
+      return crypto.timingSafeEqual(
+        Buffer.from(signature),
+        Buffer.from(expectedSignature),
+      );
+    } catch (error) {
+      this.logger.error(`HMAC comparison error: ${error.message}`);
+      return false;
+    }
   }
 
   // ============================================================================

--- a/kahade-backend/src/config/app.config.ts
+++ b/kahade-backend/src/config/app.config.ts
@@ -3,7 +3,7 @@ import { registerAs } from '@nestjs/config';
 export default registerAs('app', () => ({
   nodeEnv: process.env.NODE_ENV || 'development',
   port: parseInt(process.env.PORT, 10) || 3001,
-  apiPrefix: process.env.API_PREFIX || 'api/v1',
+  apiPrefix: process.env.API_PREFIX || 'api',
   appUrl: process.env.APP_URL || 'http://localhost:3001',
   frontendUrl: process.env.FRONTEND_URL || 'http://localhost:5000',
   

--- a/kahade-backend/src/core/auth/auth.controller.ts
+++ b/kahade-backend/src/core/auth/auth.controller.ts
@@ -1,11 +1,12 @@
-import { Controller, Post, Body, UseGuards, HttpCode, HttpStatus, Request, Get, Ip, Headers } from '@nestjs/common';
-import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth, ApiHeader } from '@nestjs/swagger';
+import { Controller, Post, Body, UseGuards, HttpCode, HttpStatus, Request, Get, Ip, Headers, Delete, Param } from '@nestjs/common';
+import { ApiTags, ApiOperation, ApiResponse, ApiBearerAuth } from '@nestjs/swagger';
 import { Throttle, SkipThrottle } from '@nestjs/throttler';
 import { AuthService } from './auth.service';
 import { RegisterDto } from './dto/register.dto';
 import { LoginDto } from './dto/login.dto';
 import { RefreshTokenDto } from './dto/refresh-token.dto';
 import { ResetPasswordDto, ForgotPasswordDto, ChangePasswordDto } from './dto/reset-password.dto';
+import { MfaVerifyDto, MfaDisableDto } from './dto/mfa-verify.dto';
 import { JwtAuthGuard } from '@common/guards/jwt-auth.guard';
 import { CurrentUser } from '@common/decorators/current-user.decorator';
 import { Public } from '@common/decorators/public.decorator';
@@ -53,7 +54,7 @@ export class AuthController {
     @Ip() ip: string,
     @Headers('user-agent') userAgent: string,
   ) {
-    return this.authService.login(loginDto);
+    return this.authService.login(loginDto, ip, userAgent);
   }
 
   // ============================================================================
@@ -183,5 +184,84 @@ export class AuthController {
   @ApiResponse({ status: 429, description: 'Too many requests' })
   async resendVerification(@Body() dto: { email: string }) {
     return this.authService.resendVerificationEmail(dto.email);
+  }
+
+  // ============================================================================
+  // MFA / 2FA
+  // ============================================================================
+
+  @Post('2fa/enable')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'Initiate MFA setup' })
+  @ApiResponse({ status: 200, description: 'Returns MFA setup details' })
+  async setupMfa(@CurrentUser('id') userId: string) {
+    return this.authService.setupMfa(userId);
+  }
+
+  @Post('2fa/verify')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'Verify MFA and enable' })
+  @ApiResponse({ status: 200, description: 'MFA enabled' })
+  async verifyMfa(
+    @CurrentUser('id') userId: string,
+    @Body() dto: MfaVerifyDto,
+  ) {
+    return this.authService.enableMfa(userId, dto.code);
+  }
+
+  @Post('2fa/disable')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'Disable MFA' })
+  @ApiResponse({ status: 200, description: 'MFA disabled' })
+  async disableMfa(
+    @CurrentUser('id') userId: string,
+    @Body() dto: MfaDisableDto,
+  ) {
+    return this.authService.disableMfa(userId, dto.password, dto.code);
+  }
+
+  // ============================================================================
+  // SESSIONS
+  // ============================================================================
+
+  @Get('sessions')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'List active sessions' })
+  @ApiResponse({ status: 200, description: 'Returns active sessions' })
+  async getSessions(@CurrentUser('id') userId: string) {
+    const sessions = await this.authService.listSessions(userId);
+    return sessions.map((session) => ({
+      id: session.id,
+      createdAt: session.createdAt,
+      expiresAt: session.expiresAt,
+      userAgent: session.userAgent,
+      ipAddress: session.ipAddress,
+      revokedAt: session.revokedAt,
+    }));
+  }
+
+  @Delete('sessions/:id')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'Revoke a session' })
+  @ApiResponse({ status: 200, description: 'Session revoked' })
+  async revokeSession(
+    @CurrentUser('id') userId: string,
+    @Param('id') sessionId: string,
+  ) {
+    return this.authService.revokeSession(userId, sessionId);
+  }
+
+  @Delete('sessions')
+  @UseGuards(JwtAuthGuard)
+  @ApiBearerAuth('JWT-auth')
+  @ApiOperation({ summary: 'Revoke all sessions' })
+  @ApiResponse({ status: 200, description: 'All sessions revoked' })
+  async revokeAllSessions(@CurrentUser('id') userId: string) {
+    return this.authService.revokeAllSessions(userId);
   }
 }

--- a/kahade-backend/src/core/auth/auth.module.ts
+++ b/kahade-backend/src/core/auth/auth.module.ts
@@ -10,6 +10,7 @@ import { LocalStrategy } from './strategies/local.strategy';
 import { UserModule } from '../user/user.module';
 
 import { SessionRepository } from './session.repository';
+import { MFAService } from './mfa.service';
 
 @Module({
   imports: [
@@ -33,6 +34,7 @@ import { SessionRepository } from './session.repository';
     JwtStrategy,
     LocalStrategy,
     SessionRepository,
+    MFAService,
   ],
   exports: [AuthService],
 })

--- a/kahade-backend/src/core/auth/auth.service.ts
+++ b/kahade-backend/src/core/auth/auth.service.ts
@@ -8,6 +8,8 @@ import { HashUtil } from '@common/utils/hash.util';
 import { IUserResponse } from '@common/interfaces/user.interface';
 import { TokenBlacklistService } from './token-blacklist.service';
 import { SessionRepository } from './session.repository';
+import { MFAService } from './mfa.service';
+import { PrismaService } from '@infrastructure/database/prisma.service';
 import * as bcrypt from 'bcrypt';
 import * as crypto from 'crypto';
 
@@ -47,6 +49,8 @@ export class AuthService {
     private readonly configService: ConfigService,
     private readonly tokenBlacklistService: TokenBlacklistService,
     private readonly sessionRepository: SessionRepository,
+    private readonly mfaService: MFAService,
+    private readonly prisma: PrismaService,
   ) {}
 
   // ============================================================================
@@ -98,7 +102,7 @@ export class AuthService {
   // LOGIN WITH BRUTE FORCE PROTECTION
   // ============================================================================
 
-  async login(loginDto: LoginDto): Promise<IAuthResponse> {
+  async login(loginDto: LoginDto, ipAddress?: string, userAgent?: string): Promise<IAuthResponse> {
     const email = loginDto.email.toLowerCase();
 
     // Check if account is locked
@@ -132,6 +136,10 @@ export class AuthService {
       });
     }
 
+    if (user.mfaEnabled) {
+      await this.verifyMfaOrThrow(user, loginDto.mfaCode);
+    }
+
     // Clear failed attempts on successful login
     this.failedAttempts.delete(email);
 
@@ -146,6 +154,8 @@ export class AuthService {
         userId: user.id,
         token: tokens.refreshToken,
         expiresAt: new Date(Date.now() + 7 * 24 * 60 * 60 * 1000),
+        ipAddress,
+        userAgent,
       });
     } catch (error) {
       this.logger.error(`Failed to store session in DB: ${error.message}`);
@@ -279,6 +289,7 @@ export class AuthService {
 
     // Revoke all sessions for this user
     const revokedCount = await this.sessionRepository.revokeAllByUserId(userId);
+    await this.tokenBlacklistService.revokeAllUserTokens(userId);
 
     this.logger.log(`User ${userId} logged out from all ${revokedCount} sessions`);
 
@@ -323,6 +334,7 @@ export class AuthService {
 
     // Revoke all sessions (force re-login)
     await this.sessionRepository.revokeAllByUserId(userId);
+    await this.tokenBlacklistService.revokeAllUserTokens(userId);
 
     this.logger.log(`Password changed for user ${userId}`);
 
@@ -374,6 +386,7 @@ export class AuthService {
 
     // Revoke all sessions
     await this.sessionRepository.revokeAllByUserId(user.id);
+    await this.tokenBlacklistService.revokeAllUserTokens(user.id);
 
     // Clear any lockouts
     this.failedAttempts.delete(user.email);
@@ -408,6 +421,99 @@ export class AuthService {
     this.logger.log(`Verification email resent to ${email}`);
 
     return { message: 'If an account exists with this email, a verification link has been sent.' };
+  }
+
+  // ============================================================================
+  // MFA MANAGEMENT
+  // ============================================================================
+
+  async setupMfa(userId: string) {
+    const user = await this.userService.findById(userId);
+    if (!user) {
+      throw new UnauthorizedException('User not found');
+    }
+
+    const setup = await this.mfaService.setupMFA(user.id, user.email);
+    const backupCodes = setup.backupCodes.map((hash) => ({ hash, used: false }));
+
+    await this.prisma.user.update({
+      where: { id: user.id },
+      data: {
+        totpSecretEnc: setup.secret,
+        backupCodesHash: backupCodes,
+        mfaEnabled: false,
+      },
+    });
+
+    return {
+      secret: setup.secret,
+      qrCodeUrl: setup.qrCodeDataURL,
+      backupCodes: setup.backupCodesPlain,
+    };
+  }
+
+  async enableMfa(userId: string, code: string): Promise<{ message: string }> {
+    const user = await this.userService.findById(userId);
+    if (!user?.totpSecretEnc) {
+      throw new BadRequestException('MFA setup is required before enabling');
+    }
+
+    await this.verifyMfaOrThrow(user, code);
+
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: { mfaEnabled: true },
+    });
+
+    return { message: 'MFA enabled successfully' };
+  }
+
+  async disableMfa(userId: string, password: string, code: string): Promise<{ message: string }> {
+    const user = await this.userService.findById(userId);
+    if (!user) {
+      throw new UnauthorizedException('User not found');
+    }
+
+    const isPasswordValid = await HashUtil.compare(password, user.passwordHash);
+    if (!isPasswordValid) {
+      throw new UnauthorizedException('Current password is incorrect');
+    }
+
+    await this.verifyMfaOrThrow(user, code);
+
+    await this.prisma.user.update({
+      where: { id: userId },
+      data: {
+        mfaEnabled: false,
+        totpSecretEnc: null,
+        backupCodesHash: null,
+      },
+    });
+
+    return { message: 'MFA disabled successfully' };
+  }
+
+  async listSessions(userId: string) {
+    return this.sessionRepository.findActiveByUserId(userId);
+  }
+
+  async revokeSession(userId: string, sessionId: string): Promise<{ message: string }> {
+    const session = await this.sessionRepository.findById(sessionId);
+    if (!session || session.userId !== userId) {
+      throw new BadRequestException('Session not found');
+    }
+
+    await this.sessionRepository.revokeById(sessionId, userId);
+    await this.tokenBlacklistService.revokeRefreshTokenHash(session.refreshHash);
+
+    return { message: 'Session revoked' };
+  }
+
+  async revokeAllSessions(userId: string): Promise<{ message: string; sessionsRevoked: number }> {
+    const revokedCount = await this.sessionRepository.revokeAllByUserId(userId);
+    await this.tokenBlacklistService.revokeAllUserTokens(userId);
+
+    return { message: 'All sessions revoked', sessionsRevoked: revokedCount };
   }
 
   // ============================================================================
@@ -550,6 +656,70 @@ export class AuthService {
         return value * 86400;
       default:
         return 900; // 15 minutes default
+    }
+  }
+
+  private async verifyMfaOrThrow(user: { id: string; mfaEnabled: boolean; totpSecretEnc?: string | null; backupCodesHash?: any }, code?: string) {
+    if (!code) {
+      throw new UnauthorizedException({
+        code: 'MFA_TOKEN_REQUIRED',
+        message: 'MFA token required',
+      });
+    }
+
+    const normalizedCode = String(code).trim();
+    let valid = false;
+
+    if (user.totpSecretEnc) {
+      valid = await this.mfaService.verifyTOTP(user.totpSecretEnc, normalizedCode);
+    }
+
+    if (!valid && user.backupCodesHash) {
+      const backupCodes = user.backupCodesHash as { hash: string; used?: boolean }[] | string[];
+
+      if (Array.isArray(backupCodes) && backupCodes.length > 0) {
+        if (typeof backupCodes[0] === 'string') {
+          for (let i = 0; i < backupCodes.length; i++) {
+            const isValid = await this.mfaService.verifyBackupCode([backupCodes[i] as string], normalizedCode);
+            if (isValid.valid) {
+              backupCodes.splice(i, 1);
+              await this.prisma.user.update({
+                where: { id: user.id },
+                data: { backupCodesHash: backupCodes },
+              });
+              valid = true;
+              break;
+            }
+          }
+        } else {
+          const hashedCodes = backupCodes as { hash: string; used?: boolean }[];
+          for (let i = 0; i < hashedCodes.length; i++) {
+            const entry = hashedCodes[i];
+            if (entry.used) continue;
+            let isValid = await this.mfaService.verifyBackupCode([entry.hash], normalizedCode);
+            if (!isValid.valid) {
+              const codeHash = crypto.createHash('sha256').update(normalizedCode).digest('hex');
+              isValid = { valid: entry.hash === codeHash };
+            }
+            if (isValid.valid) {
+              entry.used = true;
+              await this.prisma.user.update({
+                where: { id: user.id },
+                data: { backupCodesHash: hashedCodes },
+              });
+              valid = true;
+              break;
+            }
+          }
+        }
+      }
+    }
+
+    if (!valid) {
+      throw new UnauthorizedException({
+        code: 'MFA_INVALID',
+        message: 'Invalid MFA token',
+      });
     }
   }
 }

--- a/kahade-backend/src/core/auth/session.repository.ts
+++ b/kahade-backend/src/core/auth/session.repository.ts
@@ -75,6 +75,15 @@ export class SessionRepository {
   }
 
   /**
+   * BANK-GRADE: Find session by id
+   */
+  async findById(sessionId: string) {
+    return this.prisma.session.findUnique({
+      where: { id: sessionId },
+    });
+  }
+
+  /**
    * BANK-GRADE: Revoke session by token
    */
   async revoke(token: string, reason: string = 'revoked') {
@@ -92,6 +101,28 @@ export class SessionRepository {
 
     if (result.count > 0) {
       this.logger.debug(`Revoked session: ${reason}`);
+    }
+
+    return result;
+  }
+
+  /**
+   * BANK-GRADE: Revoke session by id and user
+   */
+  async revokeById(sessionId: string, userId: string) {
+    const result = await this.prisma.session.updateMany({
+      where: {
+        id: sessionId,
+        userId,
+        revokedAt: null,
+      },
+      data: {
+        revokedAt: new Date(),
+      },
+    });
+
+    if (result.count > 0) {
+      this.logger.debug(`Revoked session ${sessionId} for user ${userId}`);
     }
 
     return result;

--- a/kahade-backend/src/core/auth/token-blacklist.service.ts
+++ b/kahade-backend/src/core/auth/token-blacklist.service.ts
@@ -220,6 +220,31 @@ export class TokenBlacklistService {
   }
 
   /**
+   * BANK-GRADE: Revoke refresh token by hash
+   */
+  async revokeRefreshTokenHash(tokenHash: string, reason: string = 'revoked'): Promise<void> {
+    if (this.redis) {
+      try {
+        const data = await this.redis.get(`refresh:${tokenHash}`);
+        if (data) {
+          const parsed = JSON.parse(data);
+          await this.redis.srem(`user_tokens:${parsed.userId}`, tokenHash);
+        }
+        await this.redis.del(`refresh:${tokenHash}`);
+        return;
+      } catch (error) {
+        this.logger.error(`Redis error revoking refresh token by hash: ${error.message}`);
+      }
+    }
+
+    const entry = this.refreshTokens.get(tokenHash);
+    if (entry) {
+      entry.revokedAt = Date.now();
+      entry.revokeReason = reason;
+    }
+  }
+
+  /**
    * BANK-GRADE: Revoke all refresh tokens for a user
    */
   async revokeAllUserTokens(userId: string, reason: string = 'logout_all'): Promise<number> {

--- a/kahade-backend/src/core/user/user.controller.ts
+++ b/kahade-backend/src/core/user/user.controller.ts
@@ -10,6 +10,9 @@ import { CurrentUser } from '@common/decorators/current-user.decorator';
 import { Roles } from '@common/decorators/roles.decorator';
 import { Express } from 'express';
 
+const ALLOWED_MIME_TYPES = ['image/jpeg', 'image/png', 'image/webp', 'application/pdf'];
+const MAX_FILE_SIZE = 5 * 1024 * 1024; // 5MB
+
 @ApiTags('user')
 @Controller('user')
 @UseGuards(JwtAuthGuard)
@@ -49,12 +52,29 @@ export class UserController {
   @ApiOperation({ summary: 'Upload KYC documents' })
   @ApiConsumes('multipart/form-data')
   @ApiResponse({ status: 201, description: 'KYC documents uploaded' })
-  @UseInterceptors(FileInterceptor('document'))
+  @UseInterceptors(FileInterceptor('document', {
+    limits: { fileSize: MAX_FILE_SIZE },
+    fileFilter: (req, file, callback) => {
+      if (!ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+        return callback(new BadRequestException('Invalid file type. Allowed: JPEG, PNG, WebP, PDF'), false);
+      }
+      callback(null, true);
+    },
+  }))
   async uploadKYC(
     @CurrentUser('id') userId: string,
     @UploadedFile() file: Express.Multer.File,
     @Body() dto: UploadKycDto,
   ) {
+    if (!file) {
+      throw new BadRequestException('Document file is required');
+    }
+    if (!ALLOWED_MIME_TYPES.includes(file.mimetype)) {
+      throw new BadRequestException('Invalid file type. Allowed: JPEG, PNG, WebP, PDF');
+    }
+    if (file.size > MAX_FILE_SIZE) {
+      throw new BadRequestException('File size exceeds 5MB limit');
+    }
     return this.userService.uploadKYCDocument(userId, file, dto);
   }
 

--- a/kahade-backend/src/core/user/user.service.ts
+++ b/kahade-backend/src/core/user/user.service.ts
@@ -19,6 +19,7 @@ import * as crypto from 'crypto';
 export class UserService {
   private readonly logger = new Logger(UserService.name);
   private readonly AVATAR_UPLOAD_DIR = process.env.AVATAR_UPLOAD_DEST || './uploads/avatars';
+  private readonly KYC_UPLOAD_DIR = process.env.UPLOAD_DEST || './uploads';
 
   constructor(
     private readonly userRepository: UserRepository,
@@ -166,12 +167,22 @@ export class UserService {
     file: Express.Multer.File,
     payload: UploadKycDto,
   ): Promise<{ message: string; status: string }> {
-    const user = await this.findById(userId);
+    await this.findById(userId);
 
     // In production, upload to S3/cloud storage
-    // For now, we'll store the file path
-    const filePath = `/uploads/kyc/${userId}/${Date.now()}-${file.originalname}`;
+    // For now, we'll store the file on disk
+    const userDir = path.join(this.KYC_UPLOAD_DIR, 'kyc', userId);
+    if (!fs.existsSync(userDir)) {
+      fs.mkdirSync(userDir, { recursive: true });
+    }
+
+    const fileExt = file.originalname.split('.').pop()?.toLowerCase() || 'jpg';
     const fileHash = crypto.createHash('sha256').update(file.buffer).digest('hex');
+    const fileName = `${Date.now()}_${fileHash.substring(0, 8)}.${fileExt}`;
+    const filePath = `/uploads/kyc/${userId}/${fileName}`;
+    const fullPath = path.join(userDir, fileName);
+
+    fs.writeFileSync(fullPath, file.buffer);
 
     await this.prisma.kYCSubmission.create({
       data: {

--- a/kahade-backend/src/main.ts
+++ b/kahade-backend/src/main.ts
@@ -32,7 +32,7 @@ async function bootstrap() {
   });
 
   const configService = app.get(ConfigService);
-  const port = configService.get<number>('app.port', 3000);
+  const port = configService.get<number>('app.port', 3001);
   const apiPrefix = configService.get<string>('app.apiPrefix', 'api');
 
   // ============================================================================
@@ -78,6 +78,7 @@ async function bootstrap() {
 
   // BANK-GRADE: CORS configuration
   const corsOrigin = configService.get<string>('app.corsOrigin');
+  const corsCredentials = configService.get<boolean>('app.corsCredentials', true);
   
   // Validate CORS in production
   if (isProduction && (!corsOrigin || corsOrigin === '*')) {
@@ -95,7 +96,7 @@ async function bootstrap() {
         return;
       }
 
-      const allowedOrigins = (corsOrigin || 'http://localhost:3001')
+      const allowedOrigins = (corsOrigin || 'http://localhost:5000,http://localhost:5001,http://localhost:5002')
         .split(',')
         .map(o => o.trim());
 
@@ -106,7 +107,7 @@ async function bootstrap() {
         callback(new Error('Not allowed by CORS'));
       }
     },
-    credentials: true,
+    credentials: corsCredentials,
     methods: ['GET', 'POST', 'PUT', 'DELETE', 'PATCH', 'OPTIONS'],
     allowedHeaders: [
       'Content-Type',
@@ -189,7 +190,7 @@ async function bootstrap() {
   // SWAGGER DOCUMENTATION (Non-production only)
   // ============================================================================
 
-  const enableSwagger = configService.get<boolean>('app.enableSwagger', true);
+  const enableSwagger = configService.get<boolean>('app.enableSwagger', false);
   
   if (isProduction && enableSwagger) {
     logger.warn(

--- a/kahade-backend/src/security/guards/mfa.guard.ts
+++ b/kahade-backend/src/security/guards/mfa.guard.ts
@@ -9,6 +9,7 @@ import {
 import { Reflector } from '@nestjs/core';
 import { ConfigService } from '@nestjs/config';
 import { PrismaService } from '@infrastructure/database/prisma.service';
+import { CryptoUtil, HashUtil as BackupCodeHashUtil } from '@common/utils/crypto.util';
 import * as crypto from 'crypto';
 
 // ============================================================================
@@ -248,24 +249,52 @@ export class MfaGuard implements CanActivate {
     code: string,
   ): Promise<boolean> {
     try {
-      const codes = backupCodesHash as { hash: string; used: boolean }[];
-      const codeHash = crypto.createHash('sha256').update(code).digest('hex');
-      
-      const matchingCode = codes.find(c => c.hash === codeHash && !c.used);
-      
-      if (matchingCode) {
-        // Mark code as used
-        matchingCode.used = true;
-        
-        await this.prisma.user.update({
-          where: { id: userId },
-          data: { backupCodesHash: codes },
-        });
-        
-        this.logger.log(`Backup code used for user ${userId}`);
-        return true;
+      const codes = backupCodesHash as { hash: string; used?: boolean }[] | string[];
+
+      if (!Array.isArray(codes) || codes.length === 0) {
+        return false;
       }
-      
+
+      if (typeof codes[0] === 'string') {
+        for (let i = 0; i < codes.length; i++) {
+          const hash = codes[i] as string;
+          const isValid = await BackupCodeHashUtil.verify(code, hash);
+          if (isValid) {
+            const updatedCodes = codes.filter((_, idx) => idx !== i);
+            await this.prisma.user.update({
+              where: { id: userId },
+              data: { backupCodesHash: updatedCodes },
+            });
+            this.logger.log(`Backup code used for user ${userId}`);
+            return true;
+          }
+        }
+        return false;
+      }
+
+      const hashedCodes = codes as { hash: string; used?: boolean }[];
+      for (const entry of hashedCodes) {
+        if (entry.used) {
+          continue;
+        }
+
+        let isValid = await BackupCodeHashUtil.verify(code, entry.hash);
+        if (!isValid) {
+          const codeHash = crypto.createHash('sha256').update(code).digest('hex');
+          isValid = entry.hash === codeHash;
+        }
+
+        if (isValid) {
+          entry.used = true;
+          await this.prisma.user.update({
+            where: { id: userId },
+            data: { backupCodesHash: hashedCodes },
+          });
+          this.logger.log(`Backup code used for user ${userId}`);
+          return true;
+        }
+      }
+
       return false;
     } catch (error) {
       this.logger.error(`Backup code verification error: ${error.message}`);
@@ -284,15 +313,7 @@ export class MfaGuard implements CanActivate {
     }
     
     try {
-      const [ivHex, encrypted] = encryptedSecret.split(':');
-      const iv = Buffer.from(ivHex, 'hex');
-      const key = crypto.scryptSync(encryptionKey, 'salt', 32);
-      const decipher = crypto.createDecipheriv('aes-256-cbc', key, iv);
-      
-      let decrypted = decipher.update(encrypted, 'hex', 'utf8');
-      decrypted += decipher.final('utf8');
-      
-      return decrypted;
+      return CryptoUtil.decrypt(encryptedSecret, encryptionKey);
     } catch (error) {
       this.logger.error(`Secret decryption error: ${error.message}`);
       throw new Error('Failed to decrypt MFA secret');

--- a/kahade-frontend/client/src/contexts/AuthContext.tsx
+++ b/kahade-frontend/client/src/contexts/AuthContext.tsx
@@ -155,6 +155,7 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         email: data.email,
         username: data.username,
         password: data.password,
+        phone: data.phone,
       });
       
       const { accessToken, token, refreshToken, user: userData } = response.data;

--- a/kahade-frontend/client/src/pages/auth/Register.tsx
+++ b/kahade-frontend/client/src/pages/auth/Register.tsx
@@ -4,7 +4,7 @@
  */
 
 import { useState } from 'react';
-import { Link, useLocation } from 'wouter';
+import { Link } from 'wouter';
 import { motion } from 'framer-motion';
 import { Shield, Mail, Lock, Eye, EyeOff, ArrowRight, Loader2, User, Phone, CheckCircle2 } from 'lucide-react';
 import { Button } from '@/components/ui/button';
@@ -15,7 +15,6 @@ import { toast } from 'sonner';
 import { useAuth } from '@/contexts/AuthContext';
 
 export default function Register() {
-  const [, setLocation] = useLocation();
   const { register, isLoading } = useAuth();
   const [showPassword, setShowPassword] = useState(false);
   const [formData, setFormData] = useState({
@@ -59,7 +58,6 @@ export default function Register() {
       toast.success('Registrasi berhasil!', {
         description: 'Silakan cek email Anda untuk verifikasi.'
       });
-      setLocation('/app');
     } catch (error: any) {
       const message = error.response?.data?.message || 'Silakan coba lagi.';
       toast.error('Registrasi gagal', { description: message });


### PR DESCRIPTION
### Motivation
- Align backend defaults and CORS/Swagger behavior with frontend assumptions and secure production defaults.
- Implement end-to-end MFA and stronger session management to harden authentication and refresh-token flows.
- Harden webhook/HMAC/token comparisons to mitigate timing attacks and improve KYC upload handling for safety and determinism.
- Fix frontend registration data flow and remove a redundant client-side redirect after signup.

### Description
- Configuration and bootstrap: changed `app.apiPrefix` default to `api`, set backend default port to `3001`, added `corsCredentials` support, widened local `corsOrigin` defaults, and set `enableSwagger` off by default in `src/config/app.config.ts` and `src/main.ts`.
- MFA & sessions: added MFA wiring and endpoints in `auth.controller.ts`, enforced MFA during login and added `setupMfa`, `enableMfa`, `disableMfa`, `listSessions`, `revokeSession`, and `revokeAllSessions` flows in `auth.service.ts`, and integrated `MFAService` and `PrismaService` for storing encrypted secrets and backup codes.
- Session/token improvements: extended `SessionRepository` with `findById` and `revokeById`, and augmented `TokenBlacklistService` with `revokeRefreshTokenHash` and improved user-wide revocation support used during logout/password change.
- MFA guard & crypto: improved backup-code verification and decryption by using `CryptoUtil.decrypt` and a more flexible backup-code format in `security/guards/mfa.guard.ts`, and added timing-safe, length-checked comparisons.
- Webhooks & KYC: hardened callback and HMAC comparisons in `api/webhooks/xendit.webhook.controller.ts` with length checks and try/catch, added file-type/size validation in `user.controller.ts`, and implemented deterministic on-disk KYC storage (hashed filenames) in `user.service.ts`.
- Frontend fixes: send `phone` in registration payload in `client/src/contexts/AuthContext.tsx` and avoid a redundant `setLocation('/app')` redirect in `client/src/pages/auth/Register.tsx`.

### Testing
- No automated tests were executed as part of this change set. 
- Manual/integration test steps were not run in this rollout and should be performed (compile, unit tests, integration tests, and end-to-end flows for MFA, sessions, webhooks, and KYC uploads).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697761caf5e48324827d7ef647dfd2b0)