### PR TITLE
Add MODERATOR role and grant moderator permissions to RBAC

### DIFF
--- a/kahade-backend/src/security/rbac/permissions.enum.ts
+++ b/kahade-backend/src/security/rbac/permissions.enum.ts
@@ -136,6 +136,14 @@ export const RolePermissions: Record<string, Permission[]> = {
     Permission.ORDER_READ_ALL,
     Permission.DISPUTE_READ_ALL,
   ],
+
+  MODERATOR: [
+    Permission.USER_READ,
+    Permission.USER_UPDATE,
+    Permission.ORDER_READ_ALL,
+    Permission.DISPUTE_READ_ALL,
+    Permission.SYSTEM_AUDIT_LOG_READ,
+  ],
   
   VERIFIED_USER: [
     Permission.WALLET_READ,

--- a/kahade-backend/src/security/rbac/roles.enum.ts
+++ b/kahade-backend/src/security/rbac/roles.enum.ts
@@ -16,6 +16,9 @@ export enum Role {
   // Support Team - Customer support
   SUPPORT_MANAGER = 'SUPPORT_MANAGER',
   SUPPORT_AGENT = 'SUPPORT_AGENT',
+
+  // Moderation Team
+  MODERATOR = 'MODERATOR',
   
   // Compliance - KYC & AML
   COMPLIANCE_OFFICER = 'COMPLIANCE_OFFICER',
@@ -34,6 +37,7 @@ export const RoleHierarchy: Record<Role, number> = {
   [Role.COMPLIANCE_OFFICER]: 700,
   [Role.SUPPORT_MANAGER]: 600,
   [Role.FINANCE_OFFICER]: 500,
+  [Role.MODERATOR]: 450,
   [Role.SUPPORT_AGENT]: 400,
   [Role.PREMIUM_USER]: 300,
   [Role.VERIFIED_USER]: 200,


### PR DESCRIPTION
### Motivation
- Add explicit `MODERATOR` role to the RBAC enums and hierarchy so moderation accounts are recognized by authorization checks and to align with existing Prisma/user-role definitions and other constants.
- Prevent undefined/empty permission lookups for moderators and enable basic moderation workflows by assigning a scoped permission set.

### Description
- Added `MODERATOR = 'MODERATOR'` to the `Role` enum in `kahade-backend/src/security/rbac/roles.enum.ts` and inserted it into `RoleHierarchy` with level `450`.
- Added a `MODERATOR` entry in `RolePermissions` in `kahade-backend/src/security/rbac/permissions.enum.ts` granting `USER_READ`, `USER_UPDATE`, `ORDER_READ_ALL`, `DISPUTE_READ_ALL`, and `SYSTEM_AUDIT_LOG_READ`.
- Small ordering/fmt adjustments to keep the hierarchy consistent with other roles.

### Testing
- No automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_697839910a6c8324b666aa7772cb92a1)